### PR TITLE
Add interview tracking and vacancy KPI pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,6 +358,15 @@
       <a class="menu-btn admin-only" href="ingresos-egresos.html">
         <span class="icon">💼</span> Ingresos/Egresos Consulta
       </a>
+      <a class="menu-btn" href="vacantes.html">
+        <span class="icon">📄</span> Vacantes por Proyecto
+      </a>
+      <a class="menu-btn admin-only" href="rh-entrevistas.html">
+        <span class="icon">📝</span> Registro de Entrevistas
+      </a>
+      <a class="menu-btn admin-only" href="kpi-entrevistas.html">
+        <span class="icon">📊</span> KPI Vacantes
+      </a>
       <!-- Permitir acceso a dashboard.html para todos -->
       <a class="menu-btn" href="dashboard.html">
         <span class="icon">📋</span> Dashboard KPIs

--- a/kpi-entrevistas.html
+++ b/kpi-entrevistas.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KPI de Vacantes</title>
+</head>
+<body>
+  <h1>Indicadores de Vacantes</h1>
+  <div id="kpi"></div>
+
+  <script type="module">
+    import { db } from "./js/firebase-config.js";
+    import { collection, getDocs } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
+
+    async function calcularKPI() {
+      const entrevistasSnap = await getDocs(collection(db, 'entrevistas'));
+      let abiertos = 0, proceso = 0, cerrados = 0;
+      entrevistasSnap.forEach(doc => {
+        const estatus = doc.data().estatus;
+        if (estatus === 'Abierto') abiertos++;
+        else if (estatus === 'En proceso') proceso++;
+        else if (estatus === 'Cerrado') cerrados++;
+      });
+
+      const vacantesSnap = await getDocs(collection(db, 'vacantes'));
+      let totalVacantes = 0;
+      vacantesSnap.forEach(doc => {
+        totalVacantes += Number(doc.data().vacantes);
+      });
+
+      const sinCubrir = totalVacantes - cerrados;
+      const contenedor = document.getElementById('kpi');
+      contenedor.innerHTML = `
+        <p>Vacantes totales declaradas: ${totalVacantes}</p>
+        <p>Tickets abiertos: ${abiertos}</p>
+        <p>Tickets en proceso: ${proceso}</p>
+        <p>Tickets cerrados: ${cerrados}</p>
+        <p>Vacantes sin cubrir: ${sinCubrir}</p>
+      `;
+
+      if (sinCubrir > 10) {
+        const alerta = document.createElement('p');
+        alerta.style.color = 'red';
+        alerta.textContent = 'Alerta: hay muchas vacantes sin cubrir';
+        contenedor.appendChild(alerta);
+      }
+    }
+
+    calcularKPI();
+  </script>
+</body>
+</html>

--- a/rh-entrevistas.html
+++ b/rh-entrevistas.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Base de Entrevistas</title>
+</head>
+<body>
+  <h1>Registro de Entrevistas</h1>
+  <form id="entrevistaForm">
+    <input type="text" id="nombre" placeholder="Nombre del candidato" required />
+    <input type="text" id="puesto" placeholder="Puesto solicitado" required />
+    <input type="text" id="ticket" placeholder="Número de ticket" required />
+    <label>Fecha de creación del ticket: <input type="date" id="fechaTicket" required /></label>
+    <select id="estatus">
+      <option value="Abierto">Abierto</option>
+      <option value="En proceso">En proceso</option>
+      <option value="Cerrado">Cerrado</option>
+    </select>
+    <input type="url" id="cv" placeholder="Enlace al CV" />
+    <input type="text" id="motivo" placeholder="Motivo por no ser viable" />
+    <button type="submit">Guardar</button>
+  </form>
+
+  <h2>Entrevistas registradas</h2>
+  <table border="1">
+    <thead>
+      <tr>
+        <th>Nombre del candidato</th>
+        <th>Puesto solicitado</th>
+        <th>Número de ticket</th>
+        <th>Fecha de creación</th>
+        <th>Antigüedad (días)</th>
+        <th>Estatus</th>
+        <th>CV</th>
+        <th>Motivo no viable</th>
+      </tr>
+    </thead>
+    <tbody id="tablaEntrevistas"></tbody>
+  </table>
+
+  <script type="module">
+    import { db } from "./js/firebase-config.js";
+    import { collection, addDoc, getDocs, serverTimestamp } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
+
+    const form = document.getElementById('entrevistaForm');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const data = {
+        nombre: document.getElementById('nombre').value,
+        puesto: document.getElementById('puesto').value,
+        ticket: document.getElementById('ticket').value,
+        fechaTicket: document.getElementById('fechaTicket').value,
+        estatus: document.getElementById('estatus').value,
+        cv: document.getElementById('cv').value,
+        motivo: document.getElementById('motivo').value,
+        creado: serverTimestamp()
+      };
+      await addDoc(collection(db, 'entrevistas'), data);
+      form.reset();
+      cargarEntrevistas();
+    });
+
+    async function cargarEntrevistas() {
+      const snapshot = await getDocs(collection(db, 'entrevistas'));
+      const tbody = document.getElementById('tablaEntrevistas');
+      tbody.innerHTML = '';
+      snapshot.forEach(doc => {
+        const e = doc.data();
+        const antiguedad = Math.floor((Date.now() - new Date(e.fechaTicket)) / (1000 * 60 * 60 * 24));
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${e.nombre}</td>
+          <td>${e.puesto}</td>
+          <td>${e.ticket}</td>
+          <td>${e.fechaTicket}</td>
+          <td>${antiguedad}</td>
+          <td>${e.estatus}</td>
+          <td>${e.cv ? `<a href="${e.cv}" target="_blank">Ver CV</a>` : ''}</td>
+          <td>${e.motivo || ''}</td>
+        `;
+        tbody.appendChild(row);
+      });
+    }
+
+    cargarEntrevistas();
+  </script>
+</body>
+</html>

--- a/vacantes.html
+++ b/vacantes.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vacantes por proyecto</title>
+</head>
+<body>
+  <h1>Vacantes por proyecto</h1>
+  <form id="vacanteForm">
+    <input type="text" id="proyecto" placeholder="Proyecto" required />
+    <input type="number" id="vacantes" placeholder="Número de vacantes" required />
+    <button type="submit">Guardar</button>
+  </form>
+
+  <h2>Proyectos</h2>
+  <table border="1">
+    <thead>
+      <tr><th>Proyecto</th><th>Vacantes</th></tr>
+    </thead>
+    <tbody id="tablaVacantes"></tbody>
+  </table>
+
+  <script type="module">
+    import { db } from "./js/firebase-config.js";
+    import { collection, addDoc, getDocs } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
+
+    const form = document.getElementById('vacanteForm');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      await addDoc(collection(db, 'vacantes'), {
+        proyecto: document.getElementById('proyecto').value,
+        vacantes: Number(document.getElementById('vacantes').value)
+      });
+      form.reset();
+      cargarVacantes();
+    });
+
+    async function cargarVacantes() {
+      const snapshot = await getDocs(collection(db, 'vacantes'));
+      const tbody = document.getElementById('tablaVacantes');
+      tbody.innerHTML = '';
+      snapshot.forEach(doc => {
+        const v = doc.data();
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${v.proyecto}</td><td>${v.vacantes}</td>`;
+        tbody.appendChild(row);
+      });
+    }
+
+    cargarVacantes();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `rh-entrevistas.html` with a form to register interview data in Firestore and list records.
- Add `vacantes.html` for projects to declare open positions.
- Add `kpi-entrevistas.html` to aggregate metrics and alert when many positions remain unfilled.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae92800ce08326942cc57e7b4476f2