### PR TITLE
Add interview tracking and vacancy KPI pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,6 +358,15 @@
       <a class="menu-btn admin-only" href="ingresos-egresos.html">
         <span class="icon">💼</span> Ingresos/Egresos Consulta
       </a>
+      <a class="menu-btn" href="vacantes.html">
+        <span class="icon">📄</span> Vacantes por Proyecto
+      </a>
+      <a class="menu-btn admin-only" href="rh-entrevistas.html">
+        <span class="icon">📝</span> Registro de Entrevistas
+      </a>
+      <a class="menu-btn admin-only" href="kpi-entrevistas.html">
+        <span class="icon">📊</span> KPI Vacantes
+      </a>
       <!-- Permitir acceso a dashboard.html para todos -->
       <a class="menu-btn" href="dashboard.html">
         <span class="icon">📋</span> Dashboard KPIs

--- a/kpi-entrevistas.html
+++ b/kpi-entrevistas.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KPI de Vacantes</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    .header-accessone {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 38px 0 18px 0;
+      border-radius: 32px 32px 0 0;
+      background: linear-gradient(90deg, #2E0060 60%, #00B2A9 100%);
+      box-shadow: 0 4px 24px #2E006022;
+      position: relative;
+      animation: fadeInDown 1.1s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes fadeInDown {
+      from { opacity: 0; transform: translateY(-40px); }
+      to { opacity: 1; transform: none; }
+    }
+    .header-accessone img {
+      width: 82px;
+      height: 82px;
+      object-fit: contain;
+      border-radius: 50%;
+      background: #fff;
+      box-shadow: 0 2px 16px #FFD40033;
+      margin-bottom: 12px;
+      border: 3px solid #FFD400;
+      transition: box-shadow 0.2s;
+      animation: popInLogo 1.2s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes popInLogo {
+      from { opacity: 0; transform: scale(0.7); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .header-accessone h1 {
+      font-size: 2.2em;
+      color: #FFD400;
+      font-weight: 900;
+      letter-spacing: 2px;
+      margin: 0;
+      text-align: center;
+      text-shadow: 0 4px 16px #2E006022;
+      background: none;
+      -webkit-background-clip: unset;
+      -webkit-text-fill-color: unset;
+      animation: fadeInText 1.2s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes fadeInText {
+      from { opacity: 0; letter-spacing: 0; }
+      to { opacity: 1; letter-spacing: 2px; }
+    }
+    .user-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #fffbe7;
+      border-radius: 0 0 18px 18px;
+      padding: 12px 24px;
+      font-size: 1.08em;
+      font-weight: 700;
+      color: #2E0060;
+      box-shadow: 0 2px 8px #FFD40011;
+      margin-bottom: 18px;
+      animation: fadeInBar 1.2s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes fadeInBar {
+      from { opacity: 0; transform: translateY(-20px); }
+      to { opacity: 1; transform: none; }
+    }
+    .user-bar .user-info {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .user-bar .user-info span {
+      font-weight: 900;
+      color: #00B2A9;
+      font-size: 1.08em;
+    }
+    .logout-btn {
+      background: linear-gradient(90deg, #2E0060 60%, #00B2A9 100%);
+      color: #fff;
+      border: none;
+      border-radius: 18px;
+      padding: 8px 20px;
+      font-weight: bold;
+      cursor: pointer;
+      box-shadow: 0 2px 8px #2E006022;
+    }
+    .logout-btn:hover {
+      background: linear-gradient(90deg, #3a0077 60%, #FFD400 100%);
+      transform: scale(1.04);
+    }
+    .footer-accessone {
+      margin-top: 32px;
+      text-align: center;
+      font-size: 0.9em;
+      color: #fff;
+    }
+    .footer-accessone span {
+      color: #FFD400;
+      font-weight: 700;
+    }
+  </style>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="header-accessone">
+      <img src="logo.jpg" alt="AccessOne Logo" id="logo-accessone">
+      <h1>KPI de Vacantes</h1>
+    </div>
+    <div class="user-bar">
+      <div class="user-info"><span id="user-email">usuario@dominio.com</span></div>
+      <button id="logout-btn" class="logout-btn">Cerrar sesión</button>
+    </div>
+    <div id="kpi"></div>
+    <div class="footer-accessone">
+      &copy; <span>AccessOne</span> 2025. Todos los derechos reservados.
+    </div>
+  </div>
+
+  <script type="module">
+    import { auth, db } from './js/firebase-config.js';
+    import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+    import { collection, getDocs, doc, getDoc } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+
+    document.getElementById('logo-accessone').onclick = () => {
+      window.location.href = 'index.html';
+    };
+    document.getElementById('logout-btn').onclick = async () => {
+      await signOut(auth);
+      window.location.href = 'login.html';
+    };
+
+    onAuthStateChanged(auth, async user => {
+      if (!user) {
+        window.location.href = 'login.html';
+        return;
+      }
+      document.getElementById('user-email').textContent = user.email;
+      const snap = await getDoc(doc(db, 'users', user.uid));
+      if (!snap.exists() || snap.data().admin !== true) {
+        window.location.href = 'index.html';
+        return;
+      }
+      calcularKPI();
+    });
+
+    async function calcularKPI() {
+      const entrevistasSnap = await getDocs(collection(db, 'entrevistas'));
+      let abiertos = 0, proceso = 0, cerrados = 0;
+      entrevistasSnap.forEach(doc => {
+        const estatus = doc.data().estatus;
+        if (estatus === 'Abierto') abiertos++;
+        else if (estatus === 'En proceso') proceso++;
+        else if (estatus === 'Cerrado') cerrados++;
+      });
+
+      const vacantesSnap = await getDocs(collection(db, 'vacantes'));
+      let totalVacantes = 0, cubiertas = 0, diasAcum = 0;
+      vacantesSnap.forEach(docSnap => {
+        totalVacantes++;
+        const v = docSnap.data();
+        if (v.fechaContratacion) {
+          cubiertas++;
+          const dias = (v.fechaContratacion.toDate() - v.creado.toDate()) / 86400000;
+          diasAcum += dias;
+        }
+      });
+
+      const sinCubrir = totalVacantes - cubiertas;
+      const promedio = cubiertas ? (diasAcum / cubiertas).toFixed(1) : 0;
+      const contenedor = document.getElementById('kpi');
+      contenedor.innerHTML = `
+        <p>Vacantes totales declaradas: <strong>${totalVacantes}</strong></p>
+        <p>Vacantes cubiertas: <strong>${cubiertas}</strong></p>
+        <p>Vacantes sin cubrir: <strong>${sinCubrir}</strong></p>
+        <p>Tickets abiertos: <strong>${abiertos}</strong></p>
+        <p>Tickets en proceso: <strong>${proceso}</strong></p>
+        <p>Tickets cerrados: <strong>${cerrados}</strong></p>
+        <p>Tiempo promedio de cobertura: <strong>${promedio} días</strong></p>
+      `;
+
+      if (sinCubrir > 10) {
+        const alerta = document.createElement('p');
+        alerta.style.color = 'red';
+        alerta.textContent = 'Alerta: hay muchas vacantes sin cubrir';
+        contenedor.appendChild(alerta);
+      }
+    }
+  </script>
+</body>
+</html>
+

--- a/rh-entrevistas.html
+++ b/rh-entrevistas.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Registro de Entrevistas</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    .header-accessone {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 38px 0 18px 0;
+      border-radius: 32px 32px 0 0;
+      background: linear-gradient(90deg, #2E0060 60%, #00B2A9 100%);
+      box-shadow: 0 4px 24px #2E006022;
+      position: relative;
+      animation: fadeInDown 1.1s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes fadeInDown {
+      from { opacity: 0; transform: translateY(-40px); }
+      to { opacity: 1; transform: none; }
+    }
+    .header-accessone img {
+      width: 82px;
+      height: 82px;
+      object-fit: contain;
+      border-radius: 50%;
+      background: #fff;
+      box-shadow: 0 2px 16px #FFD40033;
+      margin-bottom: 12px;
+      border: 3px solid #FFD400;
+      transition: box-shadow 0.2s;
+      animation: popInLogo 1.2s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes popInLogo {
+      from { opacity: 0; transform: scale(0.7); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .header-accessone h1 {
+      font-size: 2.2em;
+      color: #FFD400;
+      font-weight: 900;
+      letter-spacing: 2px;
+      margin: 0;
+      text-align: center;
+      text-shadow: 0 4px 16px #2E006022;
+      background: none;
+      -webkit-background-clip: unset;
+      -webkit-text-fill-color: unset;
+      animation: fadeInText 1.2s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes fadeInText {
+      from { opacity: 0; letter-spacing: 0; }
+      to { opacity: 1; letter-spacing: 2px; }
+    }
+    .user-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #fffbe7;
+      border-radius: 0 0 18px 18px;
+      padding: 12px 24px;
+      font-size: 1.08em;
+      font-weight: 700;
+      color: #2E0060;
+      box-shadow: 0 2px 8px #FFD40011;
+      margin-bottom: 18px;
+      animation: fadeInBar 1.2s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes fadeInBar {
+      from { opacity: 0; transform: translateY(-20px); }
+      to { opacity: 1; transform: none; }
+    }
+    .user-bar .user-info {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .user-bar .user-info span {
+      font-weight: 900;
+      color: #00B2A9;
+      font-size: 1.08em;
+    }
+    .logout-btn {
+      background: linear-gradient(90deg, #2E0060 60%, #00B2A9 100%);
+      color: #fff;
+      border: none;
+      border-radius: 18px;
+      padding: 8px 20px;
+      font-weight: bold;
+      cursor: pointer;
+      box-shadow: 0 2px 8px #2E006022;
+    }
+    .logout-btn:hover {
+      background: linear-gradient(90deg, #3a0077 60%, #FFD400 100%);
+      transform: scale(1.04);
+    }
+    .footer-accessone {
+      margin-top: 32px;
+      text-align: center;
+      font-size: 0.9em;
+      color: #fff;
+    }
+    .footer-accessone span {
+      color: #FFD400;
+      font-weight: 700;
+    }
+  </style>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="header-accessone">
+      <img src="logo.jpg" alt="AccessOne Logo" id="logo-accessone">
+      <h1>Registro de Entrevistas</h1>
+    </div>
+    <div class="user-bar">
+      <div class="user-info"><span id="user-email">usuario@dominio.com</span></div>
+      <button id="logout-btn" class="logout-btn">Cerrar sesión</button>
+    </div>
+    <form id="entrevistaForm">
+      <label>Nombre del candidato
+        <input type="text" id="nombre" required />
+      </label>
+      <label>Puesto solicitado
+        <input type="text" id="puesto" required />
+      </label>
+      <label>Número de ticket (mesa de ayuda)
+        <input type="text" id="ticket" required />
+      </label>
+      <label>Fecha de creación del ticket
+        <input type="date" id="fechaTicket" required />
+      </label>
+      <label>Estatus del ticket
+        <select id="estatus">
+          <option value="Abierto">Abierto</option>
+          <option value="En proceso">En proceso</option>
+          <option value="Cerrado">Cerrado</option>
+        </select>
+      </label>
+      <label>CV adjunto (enlace)
+        <input type="url" id="cv" />
+      </label>
+      <label>Motivo por no ser viable
+        <textarea id="motivo" rows="2"></textarea>
+      </label>
+      <button type="submit">Guardar</button>
+    </form>
+
+    <h2>Entrevistas registradas</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Nombre</th>
+          <th>Puesto</th>
+          <th>Ticket</th>
+          <th>Fecha creación</th>
+          <th>Antigüedad (días)</th>
+          <th>Estatus</th>
+          <th>CV</th>
+          <th>Motivo no viable</th>
+          <th>Registrado por</th>
+        </tr>
+      </thead>
+      <tbody id="tablaEntrevistas"></tbody>
+    </table>
+    <div class="footer-accessone">
+      &copy; <span>AccessOne</span> 2025. Todos los derechos reservados.
+    </div>
+  </div>
+
+  <script type="module">
+    import { auth, db } from './js/firebase-config.js';
+    import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+    import { collection, addDoc, getDocs, serverTimestamp, doc, getDoc } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+
+    let currentUserEmail = '';
+
+    document.getElementById('logo-accessone').onclick = () => {
+      window.location.href = 'index.html';
+    };
+    document.getElementById('logout-btn').onclick = async () => {
+      await signOut(auth);
+      window.location.href = 'login.html';
+    };
+
+    onAuthStateChanged(auth, async user => {
+      if (!user) {
+        window.location.href = 'login.html';
+        return;
+      }
+      document.getElementById('user-email').textContent = user.email;
+      const snap = await getDoc(doc(db, 'users', user.uid));
+      if (!snap.exists() || snap.data().admin !== true) {
+        window.location.href = 'index.html';
+        return;
+      }
+      currentUserEmail = user.email;
+      cargarEntrevistas();
+    });
+
+    const form = document.getElementById('entrevistaForm');
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      const data = {
+        nombre: document.getElementById('nombre').value,
+        puesto: document.getElementById('puesto').value,
+        ticket: document.getElementById('ticket').value,
+        fechaTicket: document.getElementById('fechaTicket').value,
+        estatus: document.getElementById('estatus').value,
+        cv: document.getElementById('cv').value,
+        motivo: document.getElementById('motivo').value,
+        creado: serverTimestamp(),
+        creadoPor: currentUserEmail
+      };
+      await addDoc(collection(db, 'entrevistas'), data);
+      form.reset();
+      cargarEntrevistas();
+    });
+
+    async function cargarEntrevistas() {
+      const snapshot = await getDocs(collection(db, 'entrevistas'));
+      const tbody = document.getElementById('tablaEntrevistas');
+      tbody.innerHTML = '';
+      snapshot.forEach(docSnap => {
+        const e = docSnap.data();
+        const antiguedad = Math.floor((Date.now() - new Date(e.fechaTicket)) / (1000 * 60 * 60 * 24));
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${e.nombre}</td>
+          <td>${e.puesto}</td>
+          <td>${e.ticket}</td>
+          <td>${e.fechaTicket}</td>
+          <td>${antiguedad}</td>
+          <td>${e.estatus}</td>
+          <td>${e.cv ? `<a href="${e.cv}" target="_blank">Ver CV</a>` : ''}</td>
+          <td>${e.motivo || ''}</td>
+          <td>${e.creadoPor || ''}</td>
+        `;
+        tbody.appendChild(row);
+      });
+    }
+  </script>
+</body>
+</html>
+

--- a/vacantes.html
+++ b/vacantes.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vacantes por Proyecto</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    .header-accessone {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 38px 0 18px 0;
+      border-radius: 32px 32px 0 0;
+      background: linear-gradient(90deg, #2E0060 60%, #00B2A9 100%);
+      box-shadow: 0 4px 24px #2E006022;
+      position: relative;
+      animation: fadeInDown 1.1s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes fadeInDown {
+      from { opacity: 0; transform: translateY(-40px); }
+      to { opacity: 1; transform: none; }
+    }
+    .header-accessone img {
+      width: 82px;
+      height: 82px;
+      object-fit: contain;
+      border-radius: 50%;
+      background: #fff;
+      box-shadow: 0 2px 16px #FFD40033;
+      margin-bottom: 12px;
+      border: 3px solid #FFD400;
+      transition: box-shadow 0.2s;
+      animation: popInLogo 1.2s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes popInLogo {
+      from { opacity: 0; transform: scale(0.7); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .header-accessone h1 {
+      font-size: 2.2em;
+      color: #FFD400;
+      font-weight: 900;
+      letter-spacing: 2px;
+      margin: 0;
+      text-align: center;
+      text-shadow: 0 4px 16px #2E006022;
+      background: none;
+      -webkit-background-clip: unset;
+      -webkit-text-fill-color: unset;
+      animation: fadeInText 1.2s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes fadeInText {
+      from { opacity: 0; letter-spacing: 0; }
+      to { opacity: 1; letter-spacing: 2px; }
+    }
+    .user-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #fffbe7;
+      border-radius: 0 0 18px 18px;
+      padding: 12px 24px;
+      font-size: 1.08em;
+      font-weight: 700;
+      color: #2E0060;
+      box-shadow: 0 2px 8px #FFD40011;
+      margin-bottom: 18px;
+      animation: fadeInBar 1.2s cubic-bezier(.4,0,.2,1);
+    }
+    @keyframes fadeInBar {
+      from { opacity: 0; transform: translateY(-20px); }
+      to { opacity: 1; transform: none; }
+    }
+    .user-bar .user-info {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .user-bar .user-info span {
+      font-weight: 900;
+      color: #00B2A9;
+      font-size: 1.08em;
+    }
+    .logout-btn {
+      background: linear-gradient(90deg, #2E0060 60%, #00B2A9 100%);
+      color: #fff;
+      border: none;
+      border-radius: 18px;
+      padding: 8px 20px;
+      font-weight: bold;
+      cursor: pointer;
+      box-shadow: 0 2px 8px #2E006022;
+    }
+    .logout-btn:hover {
+      background: linear-gradient(90deg, #3a0077 60%, #FFD400 100%);
+      transform: scale(1.04);
+    }
+    .footer-accessone {
+      margin-top: 32px;
+      text-align: center;
+      font-size: 0.9em;
+      color: #fff;
+    }
+    .footer-accessone span {
+      color: #FFD400;
+      font-weight: 700;
+    }
+  </style>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="header-accessone">
+      <img src="logo.jpg" alt="AccessOne Logo" id="logo-accessone">
+      <h1>Vacantes por Proyecto</h1>
+    </div>
+    <div class="user-bar">
+      <div class="user-info"><span id="user-email">usuario@dominio.com</span></div>
+      <button id="logout-btn" class="logout-btn">Cerrar sesión</button>
+    </div>
+    <form id="vacanteForm">
+      <label>Proyecto
+        <input type="text" id="proyecto" list="projectList" required />
+      </label>
+      <datalist id="projectList"></datalist>
+      <label>Número de vacantes
+        <input type="number" id="vacantes" min="0" required />
+      </label>
+      <button type="submit">Guardar</button>
+    </form>
+
+    <h2>Proyectos</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Proyecto</th>
+          <th>Vacantes</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody id="tablaVacantes"></tbody>
+    </table>
+    <div class="footer-accessone">
+      &copy; <span>AccessOne</span> 2025. Todos los derechos reservados.
+    </div>
+  </div>
+
+  <script type="module">
+    import { auth, db } from './js/firebase-config.js';
+    import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+    import { collection, addDoc, getDocs, serverTimestamp, query, where, limit, updateDoc, doc } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+
+    let currentUserEmail = '';
+    let allProjects = [];
+
+    document.getElementById('logo-accessone').onclick = () => {
+      window.location.href = 'index.html';
+    };
+    document.getElementById('logout-btn').onclick = async () => {
+      await signOut(auth);
+      window.location.href = 'login.html';
+    };
+
+    onAuthStateChanged(auth, user => {
+      if (!user) {
+        window.location.href = 'login.html';
+        return;
+      }
+      document.getElementById('user-email').textContent = user.email;
+      currentUserEmail = user.email;
+      cargarProyectos().then(cargarVacantes);
+    });
+
+    const form = document.getElementById('vacanteForm');
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      const proyecto = document.getElementById('proyecto').value;
+      const num = Number(document.getElementById('vacantes').value);
+      for (let i = 0; i < num; i++) {
+        await addDoc(collection(db, 'vacantes'), {
+          proyecto,
+          creado: serverTimestamp(),
+          creadoPor: currentUserEmail,
+          fechaContratacion: null
+        });
+      }
+      await actualizarVacantesProyecto(proyecto);
+      form.reset();
+      cargarVacantes();
+    });
+    async function cargarProyectos() {
+      const snap = await getDocs(collection(db, 'project_scores'));
+      const datalist = document.getElementById('projectList');
+      datalist.innerHTML = '';
+      allProjects = [];
+      snap.forEach(docSnap => {
+        allProjects.push(docSnap.id);
+        const opt = document.createElement('option');
+        opt.value = docSnap.id;
+        datalist.appendChild(opt);
+      });
+    }
+
+    async function cargarVacantes() {
+      const snapshot = await getDocs(query(collection(db, 'vacantes'), where('fechaContratacion', '==', null)));
+      const data = {};
+      snapshot.forEach(docSnap => {
+        const v = docSnap.data();
+        if (!data[v.proyecto]) data[v.proyecto] = [];
+        data[v.proyecto].push({ id: docSnap.id, ...v });
+      });
+      const tbody = document.getElementById('tablaVacantes');
+      tbody.innerHTML = '';
+      allProjects.forEach(proj => {
+        const vacs = data[proj] || [];
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${proj}</td><td>${vacs.length}</td><td><button data-proyecto="${proj}" class="contratar-btn">Contratar</button></td>`;
+        tbody.appendChild(row);
+      });
+      document.querySelectorAll('.contratar-btn').forEach(btn => {
+        btn.addEventListener('click', () => contratarVacante(btn.dataset.proyecto));
+      });
+    }
+
+    async function contratarVacante(proyecto) {
+      const snap = await getDocs(query(collection(db, 'vacantes'), where('proyecto', '==', proyecto), where('fechaContratacion', '==', null), limit(1)));
+      if (!snap.empty) {
+        const docRef = doc(db, 'vacantes', snap.docs[0].id);
+        await updateDoc(docRef, { fechaContratacion: serverTimestamp(), contratadoPor: currentUserEmail });
+        await actualizarVacantesProyecto(proyecto);
+        cargarVacantes();
+      }
+    }
+
+    async function actualizarVacantesProyecto(proyecto) {
+      const openSnap = await getDocs(query(collection(db, 'vacantes'), where('proyecto', '==', proyecto), where('fechaContratacion', '==', null)));
+      await updateDoc(doc(db, 'project_scores', proyecto), { vacantes: openSnap.size });
+    }
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Save project vacancies in Firestore per project and update counts
- Allow marking vacancies as filled with hire dates for audit
- KPI dashboard counts covered vs open roles and reports average fill time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae92800ce08326942cc57e7b4476f2